### PR TITLE
c1-mainnet(upgrade): Besu version, blockSize, block time, gasPrice

### DIFF
--- a/c1-mainnet/config/config.toml
+++ b/c1-mainnet/config/config.toml
@@ -33,7 +33,7 @@ metrics-host="0.0.0.0"
 metrics-port=9545
 
 # miner
-min-gas-price=60000000000
+min-gas-price=40000000000
 
 # debug
 revert-reason-enabled=true

--- a/c1-mainnet/config/genesis.json
+++ b/c1-mainnet/config/genesis.json
@@ -16,6 +16,10 @@
         {
           "block": 922001,
           "blockperiodseconds": 4
+        },
+        {
+          "block": 11146000,
+          "blockperiodseconds": 2
         }
       ]
     }

--- a/c1-mainnet/docker-compose-non-linux.yml
+++ b/c1-mainnet/docker-compose-non-linux.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   besu:
-    image: ${BESU_REPO:-hyperledger/besu}:${BESU_TAG:-22.1.3}
+    image: ${BESU_REPO:-dcspark/besu}:${BESU_TAG:-22.10.1-milkomeda-c1}
     restart: "always"
     command:
       - --config-file=/config/config.toml

--- a/c1-mainnet/docker-compose.yml
+++ b/c1-mainnet/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   besu:
-    image: ${BESU_REPO:-hyperledger/besu}:${BESU_TAG:-22.1.3}
+    image: ${BESU_REPO:-dcspark/besu}:${BESU_TAG:-22.10.1-milkomeda-c1}
     restart: "always"
     command:
       - --config-file=/config/config.toml


### PR DESCRIPTION
- **EVM node upgrades on Mainnet C1**
  - Release: https://github.com/dcSpark/besu/releases/tag/22.10.1-milkomeda-c1-RC1
  - Docker image: `dcspark/besu:22.10.1-milkomeda-c1` - [dcspark/besu:22.10.1-milkomeda-c1](https://hub.docker.com/layers/dcspark/besu/22.10.1-milkomeda-c1/images/sha256-b343fe2d8bc4a52779e37f70e8292adc2d5e6f5e92dd527af45d719416765f53?context=explore)
  - Assets: [besu-22.10.1-milkomeda-c1.tar.gz](https://github.com/dcSpark/besu/releases/download/22.10.1-milkomeda-c1-RC1/besu-22.10.1-milkomeda-c1.tar.gz)
- **Network changes**
  - **blockSize limit** - _decreased_
    - from `64,937,344` gas to `32,468,672` gas
  - **minimum gasPrice** - _decreased_
    - changed from `60 Gwei` to `40 Gwei`
  - **block time** - _decreased_
    - changed from `4s` to `2s` (activated at block `11,146,000`)